### PR TITLE
'basic sanity' test checks ... sanely ;)

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -11,5 +11,5 @@ BEGIN {
     ok($cop = PL_compiling, 'returns the same reference every time');
 
     isa_ok($cop, 'B::COP');
-    is($cop->file, 't/basic.t', 'basic sanity');
+    like($cop->file, qr{t/basic.t$}, 'basic sanity');
 }


### PR DESCRIPTION
If this distribution is built, and prove called as such:

`prove -lr `pwd`/t`

...the last test in t/basic.t will fail, as it's not expecting anything but 
the last two components of the pathname.

Here we rejigger this test to look to make sure the end of $cop->file is 
t/basic.t, which should allow this to pass and preserve our sanity.

(It's not perfect, but hey, neither is my sanity.)
